### PR TITLE
Set value of X-CSRF-TOKEN-IONIC for websocket conenction

### DIFF
--- a/generators/app/templates/jhipster/_tracker.service.js
+++ b/generators/app/templates/jhipster/_tracker.service.js
@@ -6,9 +6,9 @@
         .module('main')
         .factory('JhiTrackerService', JhiTrackerService);
 
-    JhiTrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q', 'AuthServerProvider', 'Config'];
+    JhiTrackerService.$inject = ['$rootScope', '$window', '$http', '$q', '$localStorage', AuthServerProvider', 'Config'];
 
-    function JhiTrackerService ($rootScope, $window, $cookies, $http, $q, AuthServerProvider, Config) {
+    function JhiTrackerService ($rootScope, $window, $http, $q, '$localStorage', AuthServerProvider, Config) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();
@@ -39,6 +39,7 @@
             stompClient = Stomp.over(socket);
             var stateChangeStart;
             var headers = {};
+	    headers['X-CSRF-TOKEN-IONIC'] = $localStorage['X-CSRF-TOKEN'];
             stompClient.connect(headers, function() {
                 connected.resolve('success');
                 sendActivity();

--- a/generators/app/templates/jhipster/_tracker.service.js
+++ b/generators/app/templates/jhipster/_tracker.service.js
@@ -39,7 +39,7 @@
             stompClient = Stomp.over(socket);
             var stateChangeStart;
             var headers = {};
-	    headers['X-CSRF-TOKEN-IONIC'] = $localStorage['X-CSRF-TOKEN'];
+            headers['X-CSRF-TOKEN-IONIC'] = $localStorage['X-CSRF-TOKEN'];
             stompClient.connect(headers, function() {
                 connected.resolve('success');
                 sendActivity();


### PR DESCRIPTION
This change sets the X-CSRF-TOKEN-IONIC http header with the value of X-CSRF-TOKEN obtained from $localStorage. After this fix, websocket connection from android emulator works fine.
