### PR TITLE
fix angularAppName for apps that baseNames that are capitalized or end with App

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,14 +1,13 @@
 'use strict';
-var yeoman = require('yeoman-generator');
-var chalk = require('chalk');
-var shelljs = require('shelljs');
-var packagejs = require(__dirname + '/../../package.json');
-var fse = require('fs-extra');
-var jhipsterUtils = require(__dirname+ '/../../node_modules/generator-jhipster/generators/util.js');
-// Stores JHipster variables
-var jhipsterVar = {moduleName: 'ionic'};
-
-// Stores JHipster functions
+var yeoman = require('yeoman-generator'),
+    chalk = require('chalk'),
+    shelljs = require('shelljs'),
+    _ = require('lodash'),
+    packagejs = require(__dirname + '/../../package.json'),
+    fse = require('fs-extra'),
+    jhipsterUtils = require(__dirname+ '/../../node_modules/generator-jhipster/generators/util.js'),
+    // Stores JHipster variables
+    jhipsterVar = {moduleName: 'ionic'};
 
 module.exports = yeoman.Base.extend({
 
@@ -157,7 +156,7 @@ module.exports = yeoman.Base.extend({
       this.packageName = this.appConfig.packageName;
       this.packageFolder = this.appConfig.packageFolder;
       this.angularAppBaseName  = snakeToCamel(this.appConfig.baseName);
-      this.angularAppName = this.angularAppBaseName + 'App';
+      this.angularAppName = getAngularAppName(this.angularAppBaseName)
       this.searchEngine = this.appConfig.searchEngine;
       this.authenticationType = this.appConfig.authenticationType;
       this.serverPort = this.appConfig.serverPort;
@@ -508,3 +507,11 @@ function copyTemplate (source, dest, action, generator, opt, template) {
       _this.template(source, dest, _this, _opt);
   }
 };
+
+/**
+ * get the angular app name for the app.
+ */
+function getAngularAppName (baseName) {
+    return _.camelCase(baseName, true) + (baseName.endsWith('App') ? '' : 'App');
+};
+

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "generator-jhipster": ">3.1.0",
     "generator-m-ionic": "1.8.0",
     "fs-extra": "0.26.4",
+    "lodash": "4.15.0",
     "shelljs": "0.6.0",
     "cordova": "6.2.0"
   },


### PR DESCRIPTION
This fixes an issue where the angular.module was not replaced correctly, leading to a blank white browser window on startup.